### PR TITLE
Feat/sprint2 UI update

### DIFF
--- a/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
@@ -15,7 +15,6 @@ struct ChildAlbumDetailView: View {
     
     @Bindable var photo: PhotoForSwiftData
     @State private var isShowingDeleteSheet: Bool = false
-    @State private var isShowingInquirySheet: Bool = false
     @State private var isZooming: Bool = false
     
     private let photoForShare: PhotoForShare

--- a/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
@@ -16,7 +16,6 @@ struct ParentAlbumDetailView: View {
     
     @Bindable var photo: PhotoForSwiftData
     @State private var isShowingDeleteSheet: Bool = false
-    @State private var isShowingInquirySheet: Bool = false
     @State private var isZooming: Bool = false
     @State private var isLiked: Bool = false
     @State private var cancellable: AnyCancellable?

--- a/PicCharge/PicCharge/View/Setting/SettingView.swift
+++ b/PicCharge/PicCharge/View/Setting/SettingView.swift
@@ -21,7 +21,7 @@ struct SettingView: View {
     @State private var isShowingWithdrawActionSheet = false
     @State private var isShowingAlert = false
     
-    private let version = "1.0.1"
+    private let version = "1.0.0"
     
     init(myRole: Role) {
         self.myRole = myRole


### PR DESCRIPTION
## 구현 사항
- 문의하기 없애기
- 0개일때 하트 없애기
- ver 텍스트 수정
---

## 문의하기 없애기
| '문의하기 없애기'는 기존 코드 제거

## 0개일때 하트 없애기
### ChildAlbumDetailView
``` swift
            Button { } label: {
                Icon.heart
                    .font(.system(size: 50))
                    .foregroundColor(photo.likeCount > 0 ? .grpRed : .clear)
            }
            .disabled(true)
                    
            Text(photo.likeCount > 0 ? "\(photo.likeCount)개" : " ")
                .font(.body)
                .fontWeight(.bold)
            }
``` 
- icon의 경우 `photo.likeCount`가 0개일때 공간은 차지하고 있게 배치
- 아예 없애는게 아닌 .clear로 공간은 차지하고 있어야 기존 뷰의 배치가 유지됨

## ver 텍스트 수정
~~| 1.0.1로 버전 업(텍스트 변경)~~