### PR TITLE
Feat/부모, 자식 상세보기 화면 좌우 스크롤 구현

### DIFF
--- a/PicCharge/PicCharge/Model/Photo/PhotoForSwiftData.swift
+++ b/PicCharge/PicCharge/Model/Photo/PhotoForSwiftData.swift
@@ -53,3 +53,9 @@ extension PhotoForSwiftData: Hashable {
         return lhs.id == rhs.id
     }
 }
+
+extension PhotoForSwiftData {
+    static func empty() -> PhotoForSwiftData {
+        .init(uploadBy: "", sharedWith: [], imgData: Data())
+    }
+}

--- a/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
@@ -25,7 +25,7 @@ struct ChildAlbumDetailView: View {
     private let photoForShare: PhotoForShare
     
     var photo: PhotoForSwiftData {
-        photoForSwiftDatas.first { $0.id == self.selection }!
+        photoForSwiftDatas.first { $0.id == self.selection } ?? .empty()
     }
     
     init(photo: PhotoForSwiftData) {

--- a/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
@@ -29,7 +29,7 @@ struct ParentAlbumDetailView: View {
     private let photoForShare: PhotoForShare
     
     var photo: PhotoForSwiftData {
-        photoForSwiftDatas.first { $0.id == self.selection }!
+        photoForSwiftDatas.first { $0.id == self.selection } ?? .empty()
     }
     
     init(photo: PhotoForSwiftData) {


### PR DESCRIPTION
### 좌우 스크롤 

https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M09-PoHyoja/assets/75793880/ffb9ff9d-a315-429d-a827-5de167feedd2

구현
- TabView의 .tabViewStyle의 paging을 통해 사진 좌우 스크롤을 구현했습니다.
- 상세화면 진입 시, 데이터를 다시 가져오는 방향으로 정했습니다.

```swift
// swiftData 데이터 가져오기
@Query(
    sort: \PhotoForSwiftData.uploadDate,
    order: .reverse
) var photoForSwiftDatas: [PhotoForSwiftData]

// paging 바인딩
@State var selection: UUID

TabView(selection: $selection) {
    ForEach(photoForSwiftDatas) { photo in
        Image()             
            .tag(photo.id)                    
    }
}
.tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
```

<br />

- 기존 Bindable로 1장의 사진을 넘겨 받던 동작에서 같은 네이밍을 사용해서, 변경을 최소화했습니다. SwiftData에서 가져온 Query에도 Observation이 있는 것을 이용했습니다.

```swift
// 기존 방식
@Bindable var photo: PhotoForSwiftData

// 변경 방식
var photo: PhotoForSwiftData {
    photoForSwiftDatas.first { $0.id == self.selection }!
}
```

### 자잘한 사항
- 좌우 스크롤을 적용하면서 NavigationTitle의 SafeArea 충돌이 발생했습니다.
- 현재는 상하의 SafeArea까지 사진이 확대되지는 않습니다.
(상하에 검은 간격 존재)

https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M09-PoHyoja/assets/75793880/b0cb1a6c-35e8-4ef8-902d-91b5b126a350