### PR TITLE
Fix/부모 위젯 이미지 사이즈 조정

### DIFF
--- a/PicCharge/ParentWidget/ParentWidget.swift
+++ b/PicCharge/ParentWidget/ParentWidget.swift
@@ -20,11 +20,11 @@ struct ParentProvider: AppIntentTimelineProvider {
     let container: ModelContainer
     
     func placeholder(in context: Context) -> ParentEntry {
-        ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview")?.resized(toWidth: 512) ?? UIImage())
+        ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview") ?? UIImage())
     }
     
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> ParentEntry {
-        let entry = ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview")?.resized(toWidth: 512) ?? UIImage())
+        let entry = ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview") ?? UIImage())
         
         do {
             guard let user = await getUserForSwiftData() else {
@@ -38,7 +38,9 @@ struct ParentProvider: AppIntentTimelineProvider {
             if let lastPhoto = photos.last {
                 let imgData = try await FirestoreService.shared.fetchPhotoData(urlString: lastPhoto.urlString)
                 
-                return ParentEntry(date: Date(), image: (UIImage(data: imgData)?.resized(toWidth: 512) ?? UIImage(named: "ParentWidgetPreview")?.resized(toWidth: 512)!)!)
+                if let image = UIImage(data: imgData) {
+                    return ParentEntry(date: Date(), image: image)
+                }
             }
         } catch {
             return entry
@@ -48,7 +50,7 @@ struct ParentProvider: AppIntentTimelineProvider {
     }
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<ParentEntry> {
-        var entry: ParentEntry = ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview")?.resized(toWidth: 512) ?? UIImage())
+        var entry: ParentEntry = ParentEntry(date: Date(), image: UIImage(named: "ParentWidgetPreview") ?? UIImage())
         
         do {
             guard let user = await getUserForSwiftData() else {
@@ -62,7 +64,9 @@ struct ParentProvider: AppIntentTimelineProvider {
             if let lastPhoto = photos.last {
                 let imgData = try await FirestoreService.shared.fetchPhotoData(urlString: lastPhoto.urlString)
                 
-                entry = ParentEntry(date: Date(), image: (UIImage(data: imgData)?.resized(toWidth: 512) ?? UIImage(named: "ParentWidgetPreview")?.resized(toWidth: 512)!)!)
+                if let image = UIImage(data: imgData) {
+                    entry = ParentEntry(date: Date(), image: image)
+                }
             }
             
         } catch {
@@ -92,20 +96,18 @@ struct ParentWidgetView : View {
     var entry: ParentProvider.Entry
     
     var body: some View {
-        RoundedRectangle(cornerRadius: 21)
-            .fill(Color.clear)
-            .overlay(
-                Image(uiImage: entry.image.resized(toWidth: 512, isOpaque: true)!)
-                    .resizable()
-                    .aspectRatio(1, contentMode: .fit)
-                    .cornerRadius(21)
-                    .clipped()
-            )
-//            .overlay(
-//                RoundedRectangle(cornerRadius: 21)
-//                    .stroke(Color.bgSecondaryElevated, lineWidth: 20)
-//            )
-            .containerBackground(Color.clear, for: .widget)
+        GeometryReader { geometry in
+            RoundedRectangle(cornerRadius: 21)
+                .fill(Color.clear)
+                .overlay(
+                    Image(uiImage: entry.image.resized(toWidth: geometry.size.width, isOpaque: true)!)
+                        .resizable()
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .cornerRadius(21)
+                        .clipped()
+                )
+                .containerBackground(Color.clear, for: .widget)
+        }
     }
 }
 


### PR DESCRIPTION
- 수정 전
![Simulator Screenshot - iPhone 15 Pro - 2024-07-08 at 23 56 08](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M09-PoHyoja/assets/116636498/a7c190c0-d1ad-45e0-b9e9-38e046e04335)

<br>

- 수정 후
![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 00 08 13](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M09-PoHyoja/assets/116636498/c1fb5b06-6c5d-4f2a-8b63-d2564870e618)


```swift
// 기존 코드
var body: some View {
        RoundedRectangle(cornerRadius: 21)
            .fill(Color.clear)
            .overlay(
                Image(uiImage: entry.image.resized(toWidth: 512, isOpaque: true)!)
                    .resizable()
                    .aspectRatio(1, contentMode: .fit)
                    .cornerRadius(21)
                    .clipped()
            )
//            .overlay(
//                RoundedRectangle(cornerRadius: 21)
//                    .stroke(Color.bgSecondaryElevated, lineWidth: 20)
//            )
            .containerBackground(Color.clear, for: .widget)
    }


// 수정 코드
    var body: some View {
        GeometryReader { geometry in
            RoundedRectangle(cornerRadius: 21)
                .fill(Color.clear)
                .overlay(
                    Image(uiImage: entry.image.resized(toWidth: geometry.size.width, isOpaque: true)!)
                        .resizable()
                        .frame(width: geometry.size.width, height: geometry.size.height)
                        .cornerRadius(21)
                        .clipped()
                )
                .containerBackground(Color.clear, for: .widget)
        }
    }
```
- GeometryReader를 사용하여 위젯 사이즈에 맞게 이미지 크기 조정
- placeholder, snapshot 등에서 resized를 이용한 코드 삭제
- 주석 처리하지 말고 삭제하는 것이 좋다는 라뮤의 의견을 반영하여 주석 처리한 코드 삭제