### PR TITLE
fix: #134 자식 위젯 메모리 초과 이슈 수정

### DIFF
--- a/PicCharge/ParentWidget/ChildWidget.swift
+++ b/PicCharge/ParentWidget/ChildWidget.swift
@@ -48,8 +48,9 @@ struct ChildProvider: AppIntentTimelineProvider {
     }
     
     @MainActor func getLastUploadedDate() -> Date? {
-        let descriptor = FetchDescriptor<PhotoForSwiftData>(sortBy: [SortDescriptor(\.uploadDate)])
-        let date = (try? container.mainContext.fetch(descriptor))?.last?.uploadDate ?? nil
+        var descriptor = FetchDescriptor<PhotoForSwiftData>(sortBy: [SortDescriptor(\.uploadDate, order: .reverse)])
+        descriptor.fetchLimit = 1
+        let date = (try? container.mainContext.fetch(descriptor))?.first?.uploadDate ?? nil
         return date
     }
     

--- a/PicCharge/ParentWidget/ParentWidget.swift
+++ b/PicCharge/ParentWidget/ParentWidget.swift
@@ -116,7 +116,10 @@ struct ParentWidget: Widget {
     var container: ModelContainer
     
     init() {
-        FirebaseApp.configure()
+        let filePath = Bundle.main.path(forResource: "../../GoogleService-Info", ofType: "plist")!
+        let options = FirebaseOptions(contentsOfFile: filePath)
+        FirebaseApp.configure(options: options!)
+        
         do {
             container = try ModelContainer(for: UserForSwiftData.self, PhotoForSwiftData.self)
         } catch {


### PR DESCRIPTION
## 문제 상황
- TestFlight 앱에서 자식 위젯 UI가 업데이트 되지 않는 상황 발생

<img width="442" alt="스크린샷 2024-10-01 22 17 49" src="https://github.com/user-attachments/assets/859bd6bb-73c2-46e1-929f-9252db45439e">

## 문제 분석
- EXC_RESOURCE 에러 발생
- high watermark memory limit exceeded (limit = 30MB)

![image](https://github.com/user-attachments/assets/583a8e0a-f138-4429-8e2b-dddbd3ae5dcd)

```swift
// 에러가 발생한 부분의 가장 최신 사진의 UploadDate를 가져오는 로직 부분
let descriptor = FetchDescriptor<PhotoForSwiftData>(sortBy: [SortDescriptor(\.uploadDate)])
let date = (try? container.mainContext.fetch(descriptor))?.last?.uploadDate ?? nil
``` 

- 기존 코드에서는 SwiftData에 저장된 Photo를 "모두" 들고오는 로직을 수행
- 가져온 사진의 배열에서 last의 uploadDate를 반환하는 로직

> 업로드된 사진이 그대로인 상황에서 iOS 18 업데이트 직후 해당 문제가 발생한 것을 고려했을 때,
> 이미 업로드된 사진이 30MB를 초과된 상황에서도 iOS 17.5에서 로직이 정상 작동했기에
> 기존 SwiftData fetch 내부 로직이 메모리 초과를 고려해 데이터를 반환했을 가능성...으로 추정.
> iOS 18 업데이트 후, SwiftData의 fetch 로직이 변경되었을 가능성이 있다...

## 문제 해결
```swift
var descriptor = FetchDescriptor<PhotoForSwiftData>(sortBy: [SortDescriptor(\.uploadDate, order: .reverse)])
descriptor.fetchLimit = 1 // fetch 제한을 1개로 제한
let date = (try? container.mainContext.fetch(descriptor))?.first?.uploadDate ?? nil
``` 
- SwiftData의 fetchLimit 옵션을 1개로 설정
