### PR TITLE
fix: #135 navigationbar title 수정

### DIFF
--- a/PicCharge/PicCharge.xcodeproj/project.pbxproj
+++ b/PicCharge/PicCharge.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		5151CB8A2BFEE41300AF792F /* LikeAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 5151CB892BFEE41300AF792F /* LikeAnimation.json */; };
 		516978322C00CDEF00168164 /* BuggungEnd.json in Resources */ = {isa = PBXBuildFile; fileRef = 516978312C00CDEF00168164 /* BuggungEnd.json */; };
 		516978342C01B51800168164 /* BuggungEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516978332C01B51800168164 /* BuggungEndView.swift */; };
+		5172EE5D2CB66BDD001B128E /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5172EE5C2CB66BCF001B128E /* TitleView.swift */; };
 		518752072C00A8CE00005AF8 /* BuggungLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518752062C00A8CE00005AF8 /* BuggungLoadingView.swift */; };
 		518752092C00A98800005AF8 /* BuggungLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 518752082C00A98800005AF8 /* BuggungLoading.json */; };
 		51E239DA2BF636920051943D /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E239D92BF636920051943D /* Role.swift */; };
@@ -159,6 +160,7 @@
 		5151CB892BFEE41300AF792F /* LikeAnimation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = LikeAnimation.json; sourceTree = "<group>"; };
 		516978312C00CDEF00168164 /* BuggungEnd.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = BuggungEnd.json; sourceTree = "<group>"; };
 		516978332C01B51800168164 /* BuggungEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuggungEndView.swift; sourceTree = "<group>"; };
+		5172EE5C2CB66BCF001B128E /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		518752062C00A8CE00005AF8 /* BuggungLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuggungLoadingView.swift; sourceTree = "<group>"; };
 		518752082C00A98800005AF8 /* BuggungLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = BuggungLoading.json; sourceTree = "<group>"; };
 		51E239D92BF636920051943D /* Role.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
@@ -363,6 +365,7 @@
 		421A8CA92BFBBCD0003C7001 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				5172EE5C2CB66BCF001B128E /* TitleView.swift */,
 				E33AFF632BFC389800BFB665 /* ChildLoadingView.swift */,
 				518752062C00A8CE00005AF8 /* BuggungLoadingView.swift */,
 				516978332C01B51800168164 /* BuggungEndView.swift */,
@@ -661,6 +664,7 @@
 				4280468E2BF5E1AE0097EB0B /* NavigationManager.swift in Sources */,
 				4214DA292C0436CC0096D48B /* HapticManager.swift in Sources */,
 				518752072C00A8CE00005AF8 /* BuggungLoadingView.swift in Sources */,
+				5172EE5D2CB66BDD001B128E /* TitleView.swift in Sources */,
 				421A8CAF2BFDC2DE003C7001 /* PhotoForShare.swift in Sources */,
 				421A8C5C2BF885D8003C7001 /* BatteryShadowModifier.swift in Sources */,
 				421A8CC02BFE516C003C7001 /* PhotoForSwiftData.swift in Sources */,

--- a/PicCharge/PicCharge/View/Child/ChildAlbumView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildAlbumView.swift
@@ -28,6 +28,8 @@ struct ChildAlbumView: View {
         Group {
             if let first = photoForSwiftDatas.first {
                 ScrollView {
+                    TitleView(title: "앨범")
+                    
                     Divider()
                         .padding(.bottom, 10)
                     

--- a/PicCharge/PicCharge/View/Child/ChildAlbumView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildAlbumView.swift
@@ -28,10 +28,12 @@ struct ChildAlbumView: View {
         Group {
             if let first = photoForSwiftDatas.first {
                 ScrollView {
-                    TitleView(title: "앨범")
-                    
-                    Divider()
-                        .padding(.bottom, 10)
+                    VStack(spacing: 12) {
+                        TitleView(title: "앨범")
+                        
+                        Divider()
+                            .padding(.bottom, 10)
+                    }
                     
                     VStack(spacing: 8) {
                         VStack(alignment: .leading, spacing: 8) {

--- a/PicCharge/PicCharge/View/Child/ChildMainView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildMainView.swift
@@ -57,6 +57,8 @@ struct ChildMainView: View {
             .ignoresSafeArea()
             
             VStack(spacing: 12) {
+                TitleView(title: "픽-챠")
+                
                 Divider()
                     .padding(.bottom, 10)
                 

--- a/PicCharge/PicCharge/View/Child/ChildTabView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildTabView.swift
@@ -14,14 +14,14 @@ struct ChildTabView: View {
     @State private var isLoading: Bool = false
     var didRefresh: () async -> Void
     
-    var navigationTitle: String {
-        switch tab {
-        case 1: "픽-챠"
-        case 2: "앨범"
-        case 3: "설정"
-        default: ""
-        }
-    }
+//    var navigationTitle: String {
+//        switch tab {
+//        case 1: "픽-챠"
+//        case 2: "앨범"
+//        case 3: "설정"
+//        default: ""
+//        }
+//    }
     
     var body: some View {
         TabView(selection: $tab) {
@@ -55,7 +55,6 @@ struct ChildTabView: View {
         }
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.large)
-        .navigationTitle(navigationTitle)
     }
 }
 

--- a/PicCharge/PicCharge/View/Child/ChildTabView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildTabView.swift
@@ -14,15 +14,6 @@ struct ChildTabView: View {
     @State private var isLoading: Bool = false
     var didRefresh: () async -> Void
     
-//    var navigationTitle: String {
-//        switch tab {
-//        case 1: "픽-챠"
-//        case 2: "앨범"
-//        case 3: "설정"
-//        default: ""
-//        }
-//    }
-    
     var body: some View {
         TabView(selection: $tab) {
             Group {

--- a/PicCharge/PicCharge/View/Components/TitleView.swift
+++ b/PicCharge/PicCharge/View/Components/TitleView.swift
@@ -1,0 +1,23 @@
+//
+//  TitleView.swift
+//  PicCharge
+//
+//  Created by Woowon Kang on 10/9/24.
+//
+
+import SwiftUI
+
+struct TitleView: View {
+    var title: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 44)
+    }
+}

--- a/PicCharge/PicCharge/View/Setting/SettingView.swift
+++ b/PicCharge/PicCharge/View/Setting/SettingView.swift
@@ -30,6 +30,8 @@ struct SettingView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
+                TitleView(title: "설정")
+                
                 Divider()
                 
                 List {

--- a/PicCharge/PicCharge/View/Setting/SettingView.swift
+++ b/PicCharge/PicCharge/View/Setting/SettingView.swift
@@ -124,10 +124,10 @@ struct SettingView: View {
         .navigationTitle("설정")
         .alert(isPresented: $isShowingAlert) {
             Alert(
-                title: Text("뉴 런"),
-                message: Text("안뎀안뎀~~지금 시연 중임"),
-                primaryButton:  .cancel(Text("뉴런 말 듣기")),
-                secondaryButton: .destructive(Text("그래도 ㄱ")) {
+                title: Text("정말 탈퇴하시겠습니까?"),
+                message: Text("탈퇴 후에는 모든 기록이 사라집니다."),
+                primaryButton:  .cancel(Text("취소")),
+                secondaryButton: .destructive(Text("탈퇴하기")) {
                     do {
                         try logout()
                         navigationManager.userState = .notExist

--- a/PicCharge/PicCharge/View/Setting/SettingView.swift
+++ b/PicCharge/PicCharge/View/Setting/SettingView.swift
@@ -29,7 +29,7 @@ struct SettingView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
+            VStack(spacing: 12) {
                 TitleView(title: "설정")
                 
                 Divider()
@@ -121,7 +121,6 @@ struct SettingView: View {
                 .foregroundStyle(.secondary)
                 .padding(.top, 200)
         }
-        .navigationTitle("설정")
         .alert(isPresented: $isShowingAlert) {
             Alert(
                 title: Text("정말 탈퇴하시겠습니까?"),


### PR DESCRIPTION
## 개선 1 - 기존``` NavigationTitle``` 제거 후 각 뷰에 Title 따로 작성해주기
앱을 처음 켰을때 ```ChildAlbumView``` 에서 위아래로 슬라이드 시 ```NavigationTitle```이 떠 있는 현상을 해결합니다.
Components 그룹에 TitleView를 만들어 중복되는 코드를 유지보수에 유리하게 만들었습니다. 
```swift
struct TitleView: View {
    var title: String

    var body: some View {
        HStack {
            Text(title)
                .font(.largeTitle)
                .fontWeight(.bold)
            Spacer()
        }
        .padding(.horizontal, 16)
        .padding(.top, 44)
    }
}
```
각 뷰에서의 사용
### ChildMainView
``` swift
            VStack(spacing: 12) {
                TitleView(title: "픽-챠")
                // ...
            }
```
### ChildAlbumView
``` swift
           ScrollView {
                    TitleView(title: "앨범")
                // ...
            }
```
### SettingView
``` swift
           VStack(spacing: 0) {
                TitleView(title: "설정")
                // ...
            }
```

3개의 뷰 ```ChildMainView```, ```ChildAlbumView```, ```SettingView``` 에서만 사용하기에 굳이 ```TitleView```를 빼서 할 필요가 있었을까 생각했지만 추후 리팩토링 등을 고려했을때 가독성 측면에서 유리할 것으로 판단하여 진행하였습니다.


## 개선 2 - SettingView에서의 탈퇴 시 문구를 수정했습니다. 
``` swift
                // 기존
                title: Text("뉴 런"),
                message: Text("안뎀안뎀~~지금 시연 중임"),
                primaryButton:  .cancel(Text("뉴런 말 듣기")),
                secondaryButton: .destructive(Text("그래도 ㄱ")) 

                // 변경 후
                title: Text("정말 탈퇴하시겠습니까?"),
                message: Text("탈퇴 후에는 모든 기록이 사라집니다."),
                primaryButton:  .cancel(Text("취소")),
                secondaryButton: .destructive(Text("탈퇴하기")) 
```

