### PR TITLE
Feat: #173 위젯 딥링크 구현

### DIFF
--- a/PicCharge/ParentWidget/AppIntent.swift
+++ b/PicCharge/ParentWidget/AppIntent.swift
@@ -12,11 +12,3 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Configuration"
     static var description = IntentDescription("This is an example widget.")
 }
-
-struct GoToChargeIntent: AppIntent {
-    static var title: LocalizedStringResource = "충전하러가기"
-    
-    func perform() async throws -> some IntentResult {
-        return .result()
-    }
-}

--- a/PicCharge/ParentWidget/ChildWidget.swift
+++ b/PicCharge/ParentWidget/ChildWidget.swift
@@ -117,7 +117,7 @@ struct ChildWidgetEntryView : View {
                             }
                             
                             HStack {
-                                Button(intent: GoToChargeIntent()) {
+                                Link(destination: URL(string: getPercentEcododedString("widget://deeplink?route=gallery"))!) {
                                     HStack(spacing: 5) {
                                         Image(systemName: "bolt.circle.fill")
                                         Text("충전하러가기")
@@ -128,8 +128,6 @@ struct ChildWidgetEntryView : View {
                                     .background(entry.batteryPercentage <= 10 ? Color(red: 0.875, green: 0.157, blue: 0) : .accent)
                                     .clipShape(RoundedRectangle(cornerRadius: 16))
                                 }
-                                .buttonStyle(.plain)
-                                .allowsHitTesting(false)
                                 
                                 Spacer()
                             }
@@ -182,6 +180,10 @@ struct ChildWidgetEntryView : View {
             }
         }
         .background(Color.bgSecondaryElevated)
+    }
+    
+    private func getPercentEcododedString(_ string: String) -> String {
+        string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
     }
 }
 

--- a/PicCharge/PicCharge.xcodeproj/project.pbxproj
+++ b/PicCharge/PicCharge.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		420E48F22D36E5C0008944A4 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E48F12D36E5C0008944A4 /* String+.swift */; };
 		420E48F32D36E5C0008944A4 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E48F12D36E5C0008944A4 /* String+.swift */; };
 		420E48FB2D376D66008944A4 /* SignUpEmailPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E48FA2D376D66008944A4 /* SignUpEmailPasswordView.swift */; };
+		420E491A2D3EB99D008944A4 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420E49192D3EB99D008944A4 /* URL+.swift */; };
 		42141E192D2ECFD200E2609A /* SquareImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42141E182D2ECFD200E2609A /* SquareImage.swift */; };
 		4214D9EE2C0330260096D48B /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 4214D9ED2C0330260096D48B /* FirebaseFirestore */; };
 		4214D9F02C0330260096D48B /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4214D9EF2C0330260096D48B /* FirebaseFirestoreSwift */; };
@@ -177,6 +178,7 @@
 		420E48ED2D36C56A008944A4 /* FilledBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilledBtn.swift; sourceTree = "<group>"; };
 		420E48F12D36E5C0008944A4 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		420E48FA2D376D66008944A4 /* SignUpEmailPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEmailPasswordView.swift; sourceTree = "<group>"; };
+		420E49192D3EB99D008944A4 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		42141E182D2ECFD200E2609A /* SquareImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareImage.swift; sourceTree = "<group>"; };
 		4214D9FD2C0387D40096D48B /* ChildWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildWidget.swift; sourceTree = "<group>"; };
 		4214D9FF2C0387F20096D48B /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
@@ -340,6 +342,7 @@
 				421A8C682BFA3761003C7001 /* Date+.swift */,
 				4214D9FF2C0387F20096D48B /* UIImage+.swift */,
 				420E48F12D36E5C0008944A4 /* String+.swift */,
+				420E49192D3EB99D008944A4 /* URL+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -815,6 +818,7 @@
 				5172EE5D2CB66BDD001B128E /* Header.swift in Sources */,
 				421A8CAF2BFDC2DE003C7001 /* PhotoShareDTO.swift in Sources */,
 				421A8C5C2BF885D8003C7001 /* BatteryShadowModifier.swift in Sources */,
+				420E491A2D3EB99D008944A4 /* URL+.swift in Sources */,
 				421A8CC02BFE516C003C7001 /* PhotoEntity.swift in Sources */,
 				425B441E2D1FD2D2001E23FA /* User.swift in Sources */,
 				425B44262D1FDAF5001E23FA /* LocalStorageService.swift in Sources */,

--- a/PicCharge/PicCharge/Global/Extensions/URL+.swift
+++ b/PicCharge/PicCharge/Global/Extensions/URL+.swift
@@ -1,0 +1,18 @@
+//
+//  URL+.swift
+//  PicCharge
+//
+//  Created by 남유성 on 1/21/25.
+//
+
+import Foundation
+
+extension URL {
+    var queryItems: [String: String]? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value ?? "") })
+    }
+}

--- a/PicCharge/PicCharge/View/ContentView.swift
+++ b/PicCharge/PicCharge/View/ContentView.swift
@@ -80,12 +80,3 @@ struct ContentView: View {
     }
 }
 
-extension URL {
-    var queryItems: [String: String]? {
-        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
-              let queryItems = components.queryItems else {
-            return nil
-        }
-        return Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value ?? "") })
-    }
-}

--- a/PicCharge/PicCharge/View/ContentView.swift
+++ b/PicCharge/PicCharge/View/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftData
 import WidgetKit
 
 struct ContentView: View {
+    @Environment(NavigationManager.self) var navigationManager
     @Environment(UserViewModel.self) var userVM
     @Environment(PhotoViewModel.self) var photoVM
     
@@ -45,6 +46,23 @@ struct ContentView: View {
                 withAnimation { isLoading = false }
             }
         }
+        .onOpenURL { url in
+            guard url.scheme == "widget" else { return }
+            
+            if let route = url.queryItems?["route"] {
+                switch route {
+                case "gallery":
+                    Task {
+                        await userVM.checkUserState()
+                        if userVM.state == .connected(.child) && navigationManager.path.isEmpty {
+                            navigationManager.push(to: .childSendGallery)
+                        }
+                    }
+                default:
+                    print("Unknown deeplink: \(url)")
+                }
+            }
+        }
         .task {
             // 1. 유저 Auth 상태 체크
             await userVM.checkUserState()
@@ -59,5 +77,15 @@ struct ContentView: View {
             // 4. 위젯 리로드
             WidgetCenter.shared.reloadAllTimelines()
         }
+    }
+}
+
+extension URL {
+    var queryItems: [String: String]? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value ?? "") })
     }
 }


### PR DESCRIPTION
### 작업 내용
기존 AppIntent를 이용해 딥링크를 구현하는 방식을 목표로 했으나, 
해당 기능이 iOS 18 이상 부터 가능한 것으로 확인됐습니다. 
`OpenURLIntent` 기능으로 바로 구현을 할 수 있는 경우였습니다! 

https://developer.apple.com/documentation/appintents/openurlintent

이전 버전에선 `NotificationCenter` 등을 이용하는 경우도 있었지만, 좀더 간편한 `Link`를 사용해서 작업했습니다.

딥링크의 경우 scheme: widget / host: deeplink / query: route로
`"widget://deeplink?route=gallery"` 링크로 연결했습니다.

`onOpenURL`의 경우, 기존 유저가 `Child`이면서 `Connected` 상태이어야 하기 때문에 
`ContentView`에 로직을 적용했습니다.

### 스크린 샷
child의 경우
![Simulator Screen Recording - iPhone 16 - 2025-01-21 at 01 59 31](https://github.com/user-attachments/assets/29c328a4-3563-40c1-9797-4b98248a4dac)

기본
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-21 at 02 09 22](https://github.com/user-attachments/assets/34259dfe-6f47-4d12-9712-f167e49cbc3e)