### PR TITLE
Fix: #177 위젯 사진 최신 로직 수정

### DIFF
--- a/PicCharge/LocalStorageService.swift
+++ b/PicCharge/LocalStorageService.swift
@@ -30,8 +30,6 @@ protocol LocalStorageService {
     /// - Returns: 저장된 사진들의 목록 (`[Photo]`)
     func fetchPhotos() async -> [Photo]
     
-    func fetchLatestPhoto() async -> Photo?
-    
     /// 로컬 스토리지에 저장된 모든 사진 데이터를 가져옵니다.
     /// - Parameter option: 정렬 기준 파라미터
     /// - Parameter order: 정렬 순서

--- a/PicCharge/ParentWidget/ChildWidget.swift
+++ b/PicCharge/ParentWidget/ChildWidget.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 import WidgetKit
 import SwiftData
+import FirebaseCore
 
 struct ChildProvider: AppIntentTimelineProvider {
     let localStorageRepository: LocalStorageService
+    let remoteStorageRepository: RemoteStorageService
     
     func placeholder(in context: Context) -> ChildEntry {
         ChildEntry(date: Date(), configuration: ConfigurationAppIntent(), batteryPercentage: 90, lastUploadedDate: Date())
@@ -58,7 +60,9 @@ struct ChildProvider: AppIntentTimelineProvider {
     }
     
     private func getLatestUploadedDate() async -> Date {
-        await localStorageRepository.fetchLatestPhoto()?.uploadDate ?? .now
+        guard let user = await localStorageRepository.fetchUser() else { return .now }
+        
+        return await remoteStorageRepository.fetchLatestPhoto(user.name)?.uploadDate ?? .now
     }
     
     private func getUploadCycle() async -> Int {
@@ -190,16 +194,25 @@ struct ChildWidgetEntryView : View {
 struct ChildWidget: Widget {
     let kind: String = "ChildWidget"
     let localStorageRepository: LocalStorageService
+    let remoteStorageRepository: RemoteStorageService
     
     init() {
+        let filePath = Bundle.main.path(forResource: "../../GoogleService-Info", ofType: "plist")!
+        let options = FirebaseOptions(contentsOfFile: filePath)
+        FirebaseApp.configure(options: options!)
+        
         localStorageRepository = SwiftDataRepository()
+        remoteStorageRepository = FireStoreRepository(fireStore: .firestore(), storage: .storage())
     }
     
     var body: some WidgetConfiguration {
         AppIntentConfiguration(
             kind: kind,
             intent: ConfigurationAppIntent.self,
-            provider: ChildProvider(localStorageRepository: localStorageRepository)
+            provider: ChildProvider(
+                localStorageRepository: localStorageRepository,
+                remoteStorageRepository: remoteStorageRepository
+            )
         ) {
             ChildWidgetEntryView(entry: $0)
                 .containerBackground(.fill.tertiary, for: .widget)

--- a/PicCharge/ParentWidget/ParentWidget.swift
+++ b/PicCharge/ParentWidget/ParentWidget.swift
@@ -10,7 +10,6 @@ import WidgetKit
 import FirebaseCore
 import SwiftData
 
-
 // MARK: - 부모 위젯
 struct ParentProvider: AppIntentTimelineProvider {
     enum SwiftDataError: Error {
@@ -32,12 +31,10 @@ struct ParentProvider: AppIntentTimelineProvider {
                 return entry
             }
             
-            var photos: [Photo] = []
-            photos = try await remoteStorageRepository.fetchPhotos(user.name)
+            let photo = await remoteStorageRepository.fetchLatestPhoto(user.name)
             
-            if let urlString = photos.last?.urlString {
+            if let urlString = photo?.urlString {
                 let imgData = try await remoteStorageRepository.downloadPhotoData(of: urlString)
-
                 
                 if let image = UIImage(data: imgData) {
                     return ParentEntry(date: Date(), image: image)
@@ -58,10 +55,9 @@ struct ParentProvider: AppIntentTimelineProvider {
                 return Timeline(entries: [entry], policy: .atEnd)
             }
             
-            var photos: [Photo] = []
-            photos = try await remoteStorageRepository.fetchPhotos(user.name)
+            let photo = await remoteStorageRepository.fetchLatestPhoto(user.name)
             
-            if let urlString = photos.first?.urlString {
+            if let urlString = photo?.urlString {
                 let imgData = try await remoteStorageRepository.downloadPhotoData(of: urlString)
                 
                 if let image = UIImage(data: imgData) {

--- a/PicCharge/PicCharge/Service/FireStoreRepository.swift
+++ b/PicCharge/PicCharge/Service/FireStoreRepository.swift
@@ -216,6 +216,25 @@ extension FireStoreRepository {
         group.wait()
     }
     
+    
+    func fetchLatestPhoto(_ userName: String) async -> Photo? {
+        // 1. 유저 네임 check
+        guard !userName.isEmpty else { return nil }
+        
+        let document = db.collection(photoCollection)
+            .whereField("sharedWith", arrayContains: userName)
+            .order(by: "uploadDate", descending: true)
+            .limit(to: 1)
+        
+        // 2. FireStore에서 자료 가져오기
+        guard let documents = try? await document.getDocuments().documents else {
+            return nil
+        }
+        
+        // 3. DTO -> Domain으로 변환
+        return try? documents.first?.data(as: PhotoDTO_V1.self).toDomain()
+    }
+    
     func fetchPhotos(_ userName: String) async throws -> [Photo] {
         do {
             return try await _fetchPhotos(userName)

--- a/PicCharge/PicCharge/Service/SwiftDataRepository.swift
+++ b/PicCharge/PicCharge/Service/SwiftDataRepository.swift
@@ -52,13 +52,6 @@ extension SwiftDataRepository {
 
 // MARK: - Photo Entity
 extension SwiftDataRepository {
-    func fetchLatestPhoto() async -> Photo? {
-        try? photoStorage
-            .read(sortDescriptors: PhotoSortDescriptor.build(.uploadDate, order: .reverse), fetchLimit: 1)
-            .first?
-            .toDomain()
-    }
-    
     func fetchPhotos() async -> [Photo] {
         await fetchPhotos(for: .uploadDate, .reverse)
     }

--- a/PicCharge/RemoteStorageService.swift
+++ b/PicCharge/RemoteStorageService.swift
@@ -38,6 +38,8 @@ protocol RemoteStorageService {
     /// - Throws: 삭제 과정에서 오류 발생 시 예외를 던짐
     func deleteUser(_ user: User) async throws
     
+    func fetchLatestPhoto(_ userName: String) async -> Photo?
+    
     /// 유저 이름을 통해 사진 데이터를 가져옵니다.
     /// - Parameter userName: 사진을 가져올 유저 이름
     /// - Returns: 해당 유저의 사진 목록 (`[Photo]`)


### PR DESCRIPTION
### 위젯 오류

FireStoreRepository로 로직을 이동한 이후, 위젯에 로드되는 사진이 최신 사진이 아닌 경우 발생

### 해결
현재 로직에는 최신순 로직이 포함되어 있지 않아 가장 최근 사진을 불러오는 함수를 추가했습니다.

```swift
// RemoteStorageService

func fetchLatestPhoto(_ userName: String) async -> Photo?
```

```swift
let document = db.collection(photoCollection)
            .whereField("sharedWith", arrayContains: userName)
            .order(by: "uploadDate", descending: true) // 최신순
            .limit(to: 1) // 1개로 제한
```

`fetch` 후 정렬하는 로직이 아닌, `FireStore`에서 쿼리로 적용해서 1장의 데이터만 가져오도록 했습니다. 이렇게 처리를 하려면 Firebase console에서 색인 등록이 필요하더라구요!

<img width="869" alt="스크린샷 2025-01-24 01 01 19" src="https://github.com/user-attachments/assets/132d11cf-1983-4eec-ab73-d9ce75d952cd" />

색인 등록을 안하면 이렇게 터미널에 출력되는데, 해당 링크를 타고 접속하면 색인이 자동으로 등록됩니다! 페이지가 로드되면 등록되는데까지 `5분` 정도 소요되는 것 같습니다!

<img width="968" alt="스크린샷 2025-01-24 00 57 03" src="https://github.com/user-attachments/assets/367c564b-7c9e-4e68-877b-7827aa44e832" />

등록되면 이렇게 보입니다! 여기서는 `오름차순` / `내림차순`을 모두 등록해두었어요

### 참고

https://i-ten.tistory.com/226