### PR TITLE
Feat: #179 Reaction 업데이트 기능 추가

### DIFF
--- a/PicCharge/PhotoViewModel.swift
+++ b/PicCharge/PhotoViewModel.swift
@@ -53,7 +53,7 @@ extension PhotoViewModel {
             let localMap = Dictionary(uniqueKeysWithValues: localPhotos.map { ($0.id, $0) })
             
             // (1) 업데이트할 항목: 동일한 ID를 가진 항목 중 reaction이 다른 항목
-            let photosToUpdate = localMap.filter { remoteMap[$0]?.reaction != $1.reaction }.map { $0.value }
+            let photosToUpdate = remoteMap.filter { localMap[$0]?.reaction != $1.reaction }.map { $0.value }
             
             // (2) 추가할 항목: remoteMap에만 존재하는 항목
             let photosToAdd = remoteMap.filter { !localMap.keys.contains($0.key) }.map { $0.value }

--- a/PicCharge/PhotoViewModel.swift
+++ b/PicCharge/PhotoViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @Observable
 final class PhotoViewModel {
-    private(set) var photos: [Photo] = []
+    var photos: [Photo] = []
     
     @ObservationIgnored
     private let localStorageService: LocalStorageService
@@ -166,5 +166,18 @@ extension PhotoViewModel {
     /// 모든 로컬 사진을 삭제합니다.
     func deleteAllLocal() async throws {
         try await localStorageService.deleteAllPhotos()
+    }
+    
+    func updatePhoto(_ photo: Photo) async {
+        guard let targetPhoto = photos.first(where: { $0.id == photo.id }) else { return }
+        let originalReaction = targetPhoto.reaction
+        
+        do {
+            await MainActor.run { targetPhoto.reaction = photo.reaction }
+            try await remoteStorageService.updatePhoto(photo)
+            try await localStorageService.updatePhoto(photo)
+        } catch {
+            await MainActor.run { targetPhoto.reaction = originalReaction }
+        }
     }
 }

--- a/PicCharge/PicCharge/Model/Photo/Photo.swift
+++ b/PicCharge/PicCharge/Model/Photo/Photo.swift
@@ -5,13 +5,35 @@
 //  Created by 남유성 on 12/28/24.
 //
 
-import Foundation
+import SwiftUI
 
 struct Reaction: Equatable {
     var love: Int
     var fire: Int
     var star: Int
     var like: Int
+    
+    enum Kind {
+        case love, fire, star, like
+        
+        var icon: Image {
+            switch self {
+            case .love: return Icon.loveReaction
+            case .fire: return Icon.fireReaction
+            case .star: return Icon.starReaction
+            case .like: return Icon.likeReaction
+            }
+        }
+    }
+    
+    mutating func increment(for kind: Kind) {
+        switch kind {
+        case .love: self.love += 1
+        case .fire: self.fire += 1
+        case .star: self.star += 1
+        case .like: self.like += 1
+        }
+    }
 }
 
 @Observable

--- a/PicCharge/PicCharge/Service/FireStoreRepository.swift
+++ b/PicCharge/PicCharge/Service/FireStoreRepository.swift
@@ -324,7 +324,6 @@ extension FireStoreRepository {
     
     func updatePhoto(_ photo: Photo) async throws {
         do {
-            // TODO: - 카운드 업데이트 메커니즘 변경
             try await db.collection(photoCollection)
                 .document(photo.id.uuidString)
                 .updateData([

--- a/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildAlbumDetailView.swift
@@ -17,10 +17,10 @@ struct ChildAlbumDetailView: View {
     @State private var isShowingDeleteSheet: Bool = false
     @State private var isZooming: Bool = false
     
-    var loveCount: Int { 12 }
-    var fireCount: Int { 34 }
-    var starCount: Int { 56 }
-    var likeCount: Int { 78 }
+    var loveCount: Int { photo.reaction.love }
+    var fireCount: Int { photo.reaction.fire }
+    var starCount: Int { photo.reaction.star }
+    var likeCount: Int { photo.reaction.like }
     
     private var photoForShare: PhotoShareDTO {
         return PhotoShareDTO(

--- a/PicCharge/PicCharge/View/Child/ChildMainView.swift
+++ b/PicCharge/PicCharge/View/Child/ChildMainView.swift
@@ -31,10 +31,10 @@ struct ChildMainView: View {
     
     var uploadCycle: Int { userVM.user?.uploadCycle ?? 3 }
     var lastUploadDate: Date { photoVM.photos.first?.uploadDate ?? .now }
-    var loveCount: Int { 12 } // TODO: - 데이터 연결
-    var fireCount: Int { 34 } // TODO: - 데이터 연결
-    var starCount: Int { 56 } // TODO: - 데이터 연결
-    var likeCount: Int { 78 } // TODO: - 데이터 연결
+    var loveCount: Int { photoVM.photos.map { $0.reaction.love }.reduce(0, +) }
+    var fireCount: Int { photoVM.photos.map { $0.reaction.fire }.reduce(0, +) }
+    var starCount: Int { photoVM.photos.map { $0.reaction.star }.reduce(0, +) }
+    var likeCount: Int { photoVM.photos.map { $0.reaction.like }.reduce(0, +) }
     var totalUploadCount: Int { photoVM.photos.count }
     
     var body: some View {

--- a/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
@@ -48,41 +48,18 @@ struct ParentAlbumDetailView: View {
                 .tag(photo)
             }
         }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .overlay {
             if !isZooming {
                 HStack(spacing: 30) {
-                    IconBtn(Icon.loveReaction) {
-                        photo.reaction.love += 1
-                        reactionPublisher.send(photo)
-                        HapticManager.instance.impact(style: .light)
-                    }
-                    .foregroundStyle(.pink)
-                    
-                    IconBtn(Icon.fireReaction) {
-                        photo.reaction.fire += 1
-                        reactionPublisher.send(photo)
-                        HapticManager.instance.impact(style: .light)
-                    }
-                    .foregroundStyle(.yellow)
-                    
-                    IconBtn(Icon.starReaction) {
-                        photo.reaction.star += 1
-                        reactionPublisher.send(photo)
-                        HapticManager.instance.impact(style: .light)
-                    }
-                    .foregroundStyle(.teal)
-                    
-                    IconBtn(Icon.likeReaction) {
-                        photo.reaction.like += 1
-                        reactionPublisher.send(photo)
-                        HapticManager.instance.impact(style: .light)
-                    }
-                    .foregroundStyle(.purple)
+                    ReactionButton(for: .love, color: .pink)
+                    ReactionButton(for: .fire, color: .yellow)
+                    ReactionButton(for: .star, color: .teal)
+                    ReactionButton(for: .like, color: .purple)
                 }
                 .padding(.top, 450)
             }
         }
+        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .navigationTitle(photo.uploadDate.toKR())
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(isZooming ? .hidden : .visible, for: .navigationBar)
@@ -145,7 +122,16 @@ struct ParentAlbumDetailView: View {
         }
     }
     
-    
+    @ViewBuilder
+    private func ReactionButton(for reaction: Reaction.Kind, color: Color) -> some View {
+        
+        IconBtn(reaction.icon) {
+            photo.reaction.increment(for: reaction)
+            reactionPublisher.send(photo)
+            HapticManager.instance.impact(style: .light)
+        }
+        .foregroundStyle(color)
+    }
 }
 
 #Preview {

--- a/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
+++ b/PicCharge/PicCharge/View/Parent/ParentAlbumDetailView.swift
@@ -19,6 +19,8 @@ struct ParentAlbumDetailView: View {
     @State private var isShowingDeleteSheet: Bool = false
     @State private var isZooming: Bool = false
     
+    private let reactionPublisher = PassthroughSubject<Photo, Never>()
+    
     private var photoForShare: PhotoShareDTO {
         return PhotoShareDTO(
             imgData: photo.imgData ?? Data(),
@@ -31,6 +33,9 @@ struct ParentAlbumDetailView: View {
     }
     
     var body: some View {
+        let reactionDebounce = reactionPublisher
+            .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
+        
         TabView(selection: $photo) {
             ForEach(photoVM.photos) { photo in
                 VStack {
@@ -48,25 +53,29 @@ struct ParentAlbumDetailView: View {
             if !isZooming {
                 HStack(spacing: 30) {
                     IconBtn(Icon.loveReaction) {
-                        // TODO: - 카운트 연결
+                        photo.reaction.love += 1
+                        reactionPublisher.send(photo)
                         HapticManager.instance.impact(style: .light)
                     }
                     .foregroundStyle(.pink)
                     
                     IconBtn(Icon.fireReaction) {
-                        // TODO: - 카운트 연결
+                        photo.reaction.fire += 1
+                        reactionPublisher.send(photo)
                         HapticManager.instance.impact(style: .light)
                     }
                     .foregroundStyle(.yellow)
                     
                     IconBtn(Icon.starReaction) {
-                        // TODO: - 카운트 연결
+                        photo.reaction.star += 1
+                        reactionPublisher.send(photo)
                         HapticManager.instance.impact(style: .light)
                     }
                     .foregroundStyle(.teal)
                     
                     IconBtn(Icon.likeReaction) {
-                        // TODO: - 카운트 연결
+                        photo.reaction.like += 1
+                        reactionPublisher.send(photo)
                         HapticManager.instance.impact(style: .light)
                     }
                     .foregroundStyle(.purple)
@@ -103,43 +112,40 @@ struct ParentAlbumDetailView: View {
             isPresented: $isShowingDeleteSheet,
             titleVisibility: .visible
         ) {
-            VStack {
-                Button("삭제하기", role: .destructive) {
-                    Task.detached {
-                        do {
-                            // 1. 사진 삭제
-                            try await photoVM.delete(photo)
-                            // 2. 위젯 리로드
-                            WidgetCenter.shared.reloadAllTimelines()
-                            // 3. 남은 Photo 없다면 이전 화면으로
-                            await MainActor.run {
-                                if photoVM.photos.isEmpty {
-                                    navigationManager.pop()
-                                }
-                            }
-                        } catch {
-                            // 4. 에러 처리
-                            await GlobalAlert.shared.show(message: error.localizedDescription)
-                        }
-                    }
-                }
-                Button("Cancel", role: .cancel) {}
-            }
-        }
-        .onDisappear {
-            Task.detached(priority: .background) {
-                // TODO: - 좋아요 개수 업데이트 로직 추가
-            }
+            Button("삭제하기", role: .destructive) { Task.detached { await deletePhoto() } }
+            Button("Cancel", role: .cancel) {}
         }
         .onChange(of: photoVM.photos) { oldValue, newValue in
             // 현재 보고 있는 photo 업데이트
             guard let index = oldValue.firstIndex(of: photo),
                   0..<newValue.count ~= index
             else { return }
-
+            
             self.photo = newValue[index]
         }
+        .onReceive(reactionDebounce) { photo in
+            Task.detached { await photoVM.updatePhoto(photo) }
+        }
     }
+    
+    private func deletePhoto() async {
+        do {
+            // 1. 사진 삭제
+            try await photoVM.delete(photo)
+            // 2. 위젯 리로드
+            WidgetCenter.shared.reloadAllTimelines()
+            // 3. 남은 Photo 없다면 이전 화면으로
+            await MainActor.run {
+                if photoVM.photos.isEmpty { navigationManager.pop() }
+            }
+            
+        } catch {
+            // 4. 에러 처리
+            GlobalAlert.shared.show(message: error.localizedDescription)
+        }
+    }
+    
+    
 }
 
 #Preview {


### PR DESCRIPTION
### 리액션 업데이트 기능
ParentAlbumDetailView에서 리액션 버튼을 눌렀을 때, 해당 Photo의 리액션이 업데이트 되는 로직을 추가했습니다.

```swift
private let reactionPublisher = PassthroughSubject<Photo, Never>()

var body: some View {
    let reactionDebounce = reactionPublisher
        .debounce(for: .milliseconds(500), scheduler: RunLoop.main) // 500ms마다 Debounce 처리
        
    // ...
    
    .onReceive(reactionDebounce) { photo in
        Task.detached { await photoVM.updatePhoto(photo) } // 값이 들어오면 사진 데이터 업데이트
    }
}
```