### PR TITLE
Feat: #175 애플 로그인 구현

### DIFF
--- a/PicCharge/PicCharge.xcodeproj/project.pbxproj
+++ b/PicCharge/PicCharge.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		5172EE5D2CB66BDD001B128E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5172EE5C2CB66BCF001B128E /* Header.swift */; };
 		518752072C00A8CE00005AF8 /* BuggungLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518752062C00A8CE00005AF8 /* BuggungLoadingView.swift */; };
 		518752092C00A98800005AF8 /* BuggungLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 518752082C00A98800005AF8 /* BuggungLoading.json */; };
+		51B1CED62D4203EA00AA5FEA /* AppleLoginBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B1CED52D4203EA00AA5FEA /* AppleLoginBtn.swift */; };
 		51E239DA2BF636920051943D /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E239D92BF636920051943D /* Role.swift */; };
 		550FDD162BFC3DE6007A6B42 /* SignUpNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550FDD152BFC3DE6007A6B42 /* SignUpNameView.swift */; };
 		552E24E32BF9CB7500E5CF24 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E24E22BF9CB7500E5CF24 /* FirestoreService.swift */; };
@@ -238,6 +239,7 @@
 		5172EE5C2CB66BCF001B128E /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		518752062C00A8CE00005AF8 /* BuggungLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuggungLoadingView.swift; sourceTree = "<group>"; };
 		518752082C00A98800005AF8 /* BuggungLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = BuggungLoading.json; sourceTree = "<group>"; };
+		51B1CED52D4203EA00AA5FEA /* AppleLoginBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginBtn.swift; sourceTree = "<group>"; };
 		51E239D92BF636920051943D /* Role.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
 		550FDD152BFC3DE6007A6B42 /* SignUpNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpNameView.swift; sourceTree = "<group>"; };
 		550FDD172BFC48DF007A6B42 /* PicCharge.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PicCharge.entitlements; sourceTree = "<group>"; };
@@ -472,6 +474,7 @@
 				E33AFF6B2BFC3ACA00BFB665 /* LottieView.swift */,
 				42141E182D2ECFD200E2609A /* SquareImage.swift */,
 				420E48ED2D36C56A008944A4 /* FilledBtn.swift */,
+				51B1CED52D4203EA00AA5FEA /* AppleLoginBtn.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -785,6 +788,7 @@
 				42CF6FD32D22EF3C0054F244 /* SwiftDataService.swift in Sources */,
 				428046842BF5DFA50097EB0B /* ChildAlbumDetailView.swift in Sources */,
 				4214DA1A2C0392610096D48B /* ConnectionRequestsDTO.swift in Sources */,
+				51B1CED62D4203EA00AA5FEA /* AppleLoginBtn.swift in Sources */,
 				425AF6C42D34557D0056B97E /* URL.swift in Sources */,
 				420E48FB2D376D66008944A4 /* SignUpEmailPasswordView.swift in Sources */,
 				FFD221B02BFB8433009735E4 /* UserDefault+.swift in Sources */,

--- a/PicCharge/PicCharge/View/Auth/ConnectUserView.swift
+++ b/PicCharge/PicCharge/View/Auth/ConnectUserView.swift
@@ -208,7 +208,6 @@ struct ConnectUserView: View {
         .padding(.horizontal, 16)
     }
     
-    
 }
 
 
@@ -232,7 +231,6 @@ extension ConnectUserView {
             return
         }
     }
-    
     
     private func acceptConnectionRequest(currentUserName: String, request: ConnectionRequestsDTO) async {
         do {

--- a/PicCharge/PicCharge/View/Auth/MainLoginView.swift
+++ b/PicCharge/PicCharge/View/Auth/MainLoginView.swift
@@ -27,7 +27,6 @@ struct MainLoginView: View {
                     .frame(width: 188)
                 
                 Spacer()
-                Spacer()
             }
             
             VStack {

--- a/PicCharge/PicCharge/View/Auth/MainLoginView.swift
+++ b/PicCharge/PicCharge/View/Auth/MainLoginView.swift
@@ -36,6 +36,7 @@ struct MainLoginView: View {
                 FilledBtn(text: "이메일로 시작하기") {
                     navigationManager.push(to: .emailLogin)
                 }
+                AppleLoginBtn()
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 16)

--- a/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
@@ -37,7 +37,6 @@ struct SignUpNameView: View {
                     .background(.bgPrimaryElevated)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                 
-            
             Spacer()
             
             FilledBtn(text: "다음 단계",

--- a/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
@@ -91,7 +91,6 @@ struct SignUpRoleView: View {
             }
             
             Spacer()
-            Spacer()
             
             FilledBtn(text: "회원가입", isLoading: $isLoading) {
                 isLoading = true
@@ -99,8 +98,10 @@ struct SignUpRoleView: View {
                 Task.detached {
                     do {
                         if password == "" {
+                            print("Apple Login 중 회원가입 누름")
                             // 애플 회원가입
                             try await userVM.signUpWithApple(name: name, email: email, role: selectedRole)
+                            await userVM.signInWithApple()
                             
                             // 애플 회원가입 완료 후 홈 화면으로 이동
                             await MainActor.run {

--- a/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
@@ -98,10 +98,23 @@ struct SignUpRoleView: View {
                 
                 Task.detached {
                     do {
-                        try await userVM.signUp(name: name, email: email, password: password, role: selectedRole)
-                        
-                        await MainActor.run { navigationManager.pop(to: .emailLogin) }
-                        
+                        if password == "" {
+                            // 애플 회원가입
+                            try await userVM.signUpWithApple(name: name, email: email, role: selectedRole)
+                            
+                            // 애플 회원가입 완료 후 홈 화면으로 이동
+                            await MainActor.run {
+                                navigationManager.popToRoot()
+                            }
+                        } else {
+                            // 이메일 회원가입
+                            try await userVM.signUp(name: name, email: email, password: password, role: selectedRole)
+                            
+                            // 이메일 회원가입 완료 후 로그인 화면으로 이동
+                            await MainActor.run {
+                                navigationManager.pop(to: .emailLogin)
+                            }
+                        }
                     } catch {
                         await GlobalAlert.shared.show(message: email.description)
                     }

--- a/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpRoleView.swift
@@ -101,7 +101,6 @@ struct SignUpRoleView: View {
                             print("Apple Login 중 회원가입 누름")
                             // 애플 회원가입
                             try await userVM.signUpWithApple(name: name, email: email, role: selectedRole)
-                            await userVM.signInWithApple()
                             
                             // 애플 회원가입 완료 후 홈 화면으로 이동
                             await MainActor.run {

--- a/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
+++ b/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
@@ -9,38 +9,23 @@ import SwiftUI
 import AuthenticationServices
 
 struct AppleLoginBtn: View {
+    @Environment(UserViewModel.self) var userVM
+    
     var body: some View {
         SignInWithAppleButton(
             .continue,
             onRequest: { request in
-                request.requestedScopes = [.fullName, .email]
+                userVM.configureAppleSignInRequest(request)
             },
             onCompletion: { result in
-                switch result {
-                case .success(let authResults):
-                    print("Apple Login Successful")
-                    switch authResults.credential{
-                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        // 계정 정보 가져오기
-                        let UserIdentifier = appleIDCredential.user
-                        let fullName = appleIDCredential.fullName
-                        let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                        let email = appleIDCredential.email
-                        let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8)
-                        let AuthorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8)
-                    default:
-                        break
-                    }
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    print("error")
+                Task {
+                    await userVM.processAppleSignInResult(result) // 결과 처리 간소화
                 }
             }
         )
         .signInWithAppleButtonStyle(.white)
         .frame(height: 54)
         .clipShape(RoundedRectangle(cornerRadius: 14))
-        
     }
 }
 

--- a/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
+++ b/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
@@ -20,12 +20,19 @@ struct AppleLoginBtn: View {
             },
             onCompletion: { result in
                 Task {
-                    if let email = await userVM.processAppleSignInResult(result) {
-                        // SignUpNameView로 이메일과 더미 비밀번호 전달
-                        navigationManager.push(to: .signUpName(
-                            email: email,
-                            password: ""
-                        ))
+                    if let (isNewUser, email) = await userVM.processAppleSignInResult(result) {
+                        if isNewUser {
+                            // 새 사용자 => 회원가입 플로우
+                            print("Apple 회원가입, 이름입력하러 가자")
+                            navigationManager.push(to: .signUpName(
+                                email: email,
+                                password: "" // 애플 회원가입용
+                            ))
+                        } else {
+                            // 기존 사용자 => 홈 화면
+                            await userVM.signInWithApple()
+                            navigationManager.popToRoot()
+                        }
                     } else {
                         print("Apple 로그인 실패 또는 취소됨")
                     }

--- a/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
+++ b/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
@@ -1,0 +1,49 @@
+//
+//  AppleLoginBtn.swift
+//  PicCharge
+//
+//  Created by Woowon Kang on 1/23/25.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct AppleLoginBtn: View {
+    var body: some View {
+        SignInWithAppleButton(
+            .continue,
+            onRequest: { request in
+                request.requestedScopes = [.fullName, .email]
+            },
+            onCompletion: { result in
+                switch result {
+                case .success(let authResults):
+                    print("Apple Login Successful")
+                    switch authResults.credential{
+                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                        // 계정 정보 가져오기
+                        let UserIdentifier = appleIDCredential.user
+                        let fullName = appleIDCredential.fullName
+                        let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+                        let email = appleIDCredential.email
+                        let IdentityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8)
+                        let AuthorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8)
+                    default:
+                        break
+                    }
+                case .failure(let error):
+                    print(error.localizedDescription)
+                    print("error")
+                }
+            }
+        )
+        .signInWithAppleButtonStyle(.white)
+        .frame(height: 54)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        
+    }
+}
+
+#Preview {
+    AppleLoginBtn()
+}

--- a/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
+++ b/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
@@ -10,6 +10,7 @@ import AuthenticationServices
 
 struct AppleLoginBtn: View {
     @Environment(UserViewModel.self) var userVM
+    @Environment(NavigationManager.self) var navigationManager
     
     var body: some View {
         SignInWithAppleButton(
@@ -19,7 +20,15 @@ struct AppleLoginBtn: View {
             },
             onCompletion: { result in
                 Task {
-                    await userVM.processAppleSignInResult(result) // 결과 처리 간소화
+                    if let email = await userVM.processAppleSignInResult(result) {
+                        // SignUpNameView로 이메일과 더미 비밀번호 전달
+                        navigationManager.push(to: .signUpName(
+                            email: email,
+                            password: ""
+                        ))
+                    } else {
+                        print("Apple 로그인 실패 또는 취소됨")
+                    }
                 }
             }
         )

--- a/PicCharge/PicCharge/View/Setting/SettingView.swift
+++ b/PicCharge/PicCharge/View/Setting/SettingView.swift
@@ -123,7 +123,7 @@ struct SettingView: View {
             Alert(
                 title: Text("정말 탈퇴하시겠습니까?"),
                 message: Text("탈퇴 후에는 모든 기록이 사라집니다."),
-                primaryButton:  .cancel(Text("취소")),
+                primaryButton: .cancel(Text("취소")),
                 secondaryButton: .destructive(Text("탈퇴하기")) {
                     Task.detached {
                         do {

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -21,7 +21,9 @@ final class UserViewModel {
     
     private(set) var user: User?
     var state: State = .checkNeeded
-    private(set) var nounce: String = ""
+    
+    @ObservationIgnored
+    private var nounce: String = ""
     
     @ObservationIgnored
     private let localStorageService: LocalStorageService

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -151,11 +151,26 @@ final class UserViewModel {
     }
     
     func signUp(name: String, email: String, password: String, role: Role) async throws {
-        _ = try await Auth.auth().createUser(withEmail: email, password: password)
+        //_ = try await Auth.auth().createUser(withEmail: email, password: password)
+        do {
+            _ = try await Auth.auth().createUser(withEmail: email, password: password)
+            print("Firebase Auth 사용자 생성 성공: \(email)")
+        } catch let error as NSError {
+            print("Firebase Auth 에러 - 코드: \(error.code), 메시지: \(error.localizedDescription)")
+            throw error
+        }
         
         let user = User(name: name, role: role, email: email, connectedTo: [])
         
         try await remoteStorageService.addUser(user)
+    }
+    
+    func signUpWithApple(name: String, email: String, role: Role) async throws {
+        // Firebase Auth에는 이미 계정이 있으므로 Firestore에만 저장
+        let user = User(name: name, role: role, email: email, connectedTo: [])
+        try await remoteStorageService.addUser(user)
+        
+        print("애플 회원가입(추가 정보) 완료 - \(email)")
     }
     
     func logOut() async throws {
@@ -177,7 +192,6 @@ final class UserViewModel {
         //TODO: 현재는 탈퇴하기 눌러도 로그아웃 처리, 추후 탈퇴기능 논의
         try await logOut()
     }
-    
     
 }
 
@@ -248,25 +262,30 @@ extension UserViewModel {
         return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
     
-    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async {
+    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> String? {
         switch result {
         case .success(let authorization):
             if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
                 do {
-                    try await performFirebaseSignIn(with: credential) // Apple Credential로 Firebase 인증 처리
+                    // Firebase 인증 후 이메일 반환
+                    let email = try await performFirebaseSignIn(with: credential)
+                    return email
                 } catch {
                     print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
+                    return nil
                 }
             } else {
                 print("Apple Sign-In 실패: Credential 변환 실패")
+                return nil
             }
         case .failure(let error):
             print("Apple Sign-In 에러: \(error.localizedDescription)")
+            return nil
         }
     }
 
     // Apple Credential을 사용해 Firebase 인증 처리
-    func performFirebaseSignIn(with credential: ASAuthorizationAppleIDCredential) async throws {
+    func performFirebaseSignIn(with credential: ASAuthorizationAppleIDCredential) async throws -> String {
         // 1. Apple에서 제공한 identityToken을 가져와 Firebase 인증에 사용
         guard let identityToken = credential.identityToken,
               let tokenString = String(data: identityToken, encoding: .utf8) else {
@@ -281,13 +300,12 @@ extension UserViewModel {
         )
 
         do {
-            // 3. Firebase 인증 요청
             let authResult = try await Auth.auth().signIn(with: firebaseCredential)
-
-            // 4. Firebase 인증 성공 시 사용자 정보 디버깅 출력
-            print("Firebase Auth 성공: \(authResult.user.email ?? "Unknown email")")
-
-            // TODO: Firestore에서 사용자 정보 확인 및 로컬 데이터 저장 추가 가능
+            guard let email = authResult.user.email else {
+                throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Email not found in Firebase Auth result"])
+            }
+            print("Firebase Auth 성공: \(email)")
+            return email
         } catch {
             print("Firebase Auth 실패: \(error.localizedDescription)")
             throw error

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -40,6 +40,7 @@ final class UserViewModel {
     func checkUserState() async {
         // 1. Local User 확인
         guard let user = await localStorageService.fetchUser() else {
+            print("[checkUserState] 로컬 유저 없음 → state = .notExist")
             await MainActor.run { self.state = .notExist }
             return
         }
@@ -61,9 +62,9 @@ final class UserViewModel {
                 self.user = user
                 self.state = .notConnected
             }
+            print("부모자식 연결 안됨: \(self.state)")
             return
         }
-        
         print("--swiftDataUser 정보--")
         print("name: \(user.name)")
         print("role: \(user.role)")
@@ -140,7 +141,6 @@ final class UserViewModel {
                  try Auth.auth().signOut()
                  return
              }
-            
              try await localStorageService.addUser(user)
              
              // 4. VM State 업데이트
@@ -160,8 +160,6 @@ final class UserViewModel {
                  switch authError {
                  case .invalidEmail:
                      await GlobalAlert.shared.show(message: "이메일 형식이 올바르지 않습니다.")
-                 case .wrongPassword:
-                     await GlobalAlert.shared.show(message: "비밀번호가 맞지 않습니다.")
                  case .userDisabled:
                      await GlobalAlert.shared.show(message: "사용할 수 없는 계정입니다.")
                  default:
@@ -220,14 +218,13 @@ final class UserViewModel {
         // Firebase Auth에는 이미 계정이 있으므로 Firestore에만 저장
         let user = User(name: name, role: role, email: email, connectedTo: [])
         
+        try await remoteStorageService.addUser(user)
+        try await localStorageService.addUser(user)
+        
         await MainActor.run {
             self.user = user
             self.state = .notConnected
         }
-        
-        try await remoteStorageService.addUser(user)
-        
-        print("애플 회원가입(추가 정보) 완료 - \(email)")
     }
     
     func logOut() async throws {
@@ -319,53 +316,52 @@ extension UserViewModel {
         return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
     
-    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> String? {
-        switch result {
-        case .success(let authorization):
-            if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
-                do {
-                    // Firebase 인증 후 이메일 반환
-                    let email = try await performFirebaseSignIn(with: credential)
-                    return email
-                } catch {
-                    print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
+    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> (Bool, String)? {
+            switch result {
+            case .success(let authorization):
+                if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+                    do {
+                        let (isNewUser, email) = try await performAppleFirebaseSignIn(credential: credential)
+                        return (isNewUser, email)
+                    } catch {
+                        print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
+                        return nil
+                    }
+                } else {
+                    print("Apple Sign-In 실패: Credential 변환 실패")
                     return nil
                 }
-            } else {
-                print("Apple Sign-In 실패: Credential 변환 실패")
+            case .failure(let error):
+                print("Apple Sign-In 에러: \(error.localizedDescription)")
                 return nil
             }
-        case .failure(let error):
-            print("Apple Sign-In 에러: \(error.localizedDescription)")
-            return nil
         }
-    }
-
-    // Apple Credential을 사용해 Firebase 인증 처리
-    func performFirebaseSignIn(with credential: ASAuthorizationAppleIDCredential) async throws -> String {
-        // 1. Apple에서 제공한 identityToken을 가져와 Firebase 인증에 사용
+    
+    private func performAppleFirebaseSignIn(credential: ASAuthorizationAppleIDCredential) async throws -> (Bool, String) {
         guard let identityToken = credential.identityToken,
               let tokenString = String(data: identityToken, encoding: .utf8) else {
             throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid token"])
         }
-
-        // 2. Firebase 인증을 위한 Credential 생성
+        
         let firebaseCredential = OAuthProvider.credential(
             withProviderID: "apple.com",
             idToken: tokenString,
             rawNonce: nounce
         )
-
-        do {
-            let authResult = try await Auth.auth().signIn(with: firebaseCredential)
-            guard let email = authResult.user.email else {
-                throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Email not found in Firebase Auth result"])
-            }
-            print("Firebase Auth 성공: \(email)")
-            return email
-        } catch {
-            print("Firebase Auth 실패: \(error.localizedDescription)")
-            throw error
+        
+        let authResult = try await Auth.auth().signIn(with: firebaseCredential)
+        
+        guard let email = authResult.user.email else {
+            throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing email"])
+        }
+        
+        // Firestore 조회
+        if let _ = try await remoteStorageService.fetchUserByEmail(email) {
+            // 기존 유저
+            return (false, email)
+        } else {
+            // 새 유저
+            return (true, email)
         }
     }
 }

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import AuthenticationServices
+import CryptoKit
 import FirebaseAuth
 
 @Observable
@@ -19,6 +21,7 @@ final class UserViewModel {
     
     private(set) var user: User?
     var state: State = .checkNeeded
+    private(set) var nounce: String = ""
     
     @ObservationIgnored
     private let localStorageService: LocalStorageService
@@ -174,6 +177,8 @@ final class UserViewModel {
         //TODO: 현재는 탈퇴하기 눌러도 로그아웃 처리, 추후 탈퇴기능 논의
         try await logOut()
     }
+    
+    
 }
 
 extension UserViewModel {
@@ -194,5 +199,98 @@ extension UserViewModel {
         try await localStorageService.addConnection(of: user, with: [])
         
         await MainActor.run { self.user?.connectedTo += [userName] }
+    }
+}
+
+// Apple Login에 필요한 기능 구현
+extension UserViewModel {
+
+    // Apple 로그인 시작
+    func configureAppleSignInRequest(_ request: ASAuthorizationAppleIDRequest) {
+        self.nounce = randomNonceString()
+        request.requestedScopes = [.email, .fullName]
+        request.nonce = sha256(nounce)
+    }
+    
+    // Nonce 생성
+    func randomNonceString(length: Int = 32) -> String {
+        let charset: [Character] =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 { return }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+
+    // SHA256 해싱
+    func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+    
+    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async {
+        switch result {
+        case .success(let authorization):
+            if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+                do {
+                    try await performFirebaseSignIn(with: credential) // Apple Credential로 Firebase 인증 처리
+                } catch {
+                    print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
+                }
+            } else {
+                print("Apple Sign-In 실패: Credential 변환 실패")
+            }
+        case .failure(let error):
+            print("Apple Sign-In 에러: \(error.localizedDescription)")
+        }
+    }
+
+    // Apple Credential을 사용해 Firebase 인증 처리
+    func performFirebaseSignIn(with credential: ASAuthorizationAppleIDCredential) async throws {
+        // 1. Apple에서 제공한 identityToken을 가져와 Firebase 인증에 사용
+        guard let identityToken = credential.identityToken,
+              let tokenString = String(data: identityToken, encoding: .utf8) else {
+            throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid token"])
+        }
+
+        // 2. Firebase 인증을 위한 Credential 생성
+        let firebaseCredential = OAuthProvider.credential(
+            withProviderID: "apple.com",
+            idToken: tokenString,
+            rawNonce: nounce
+        )
+
+        do {
+            // 3. Firebase 인증 요청
+            let authResult = try await Auth.auth().signIn(with: firebaseCredential)
+
+            // 4. Firebase 인증 성공 시 사용자 정보 디버깅 출력
+            print("Firebase Auth 성공: \(authResult.user.email ?? "Unknown email")")
+
+            // TODO: Firestore에서 사용자 정보 확인 및 로컬 데이터 저장 추가 가능
+        } catch {
+            print("Firebase Auth 실패: \(error.localizedDescription)")
+            throw error
+        }
     }
 }

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -255,18 +255,14 @@ extension UserViewModel {
         
         try await remoteStorageService.updateConnections(of: user, with: [otherUser.name])
         try await remoteStorageService.updateConnections(of: otherUser, with: [user.name])
-        
         try await addLocalConnections(with: otherUser.name)
-        
-        await MainActor.run { self.user?.connectedTo += [otherUser.name] }
     }
     
-    func addLocalConnections(with userName: String) async throws {
+    func addLocalConnections(with otherUserName: String) async throws {
         guard let user else { return }
         
-        try await localStorageService.addConnection(of: user, with: [])
-        
-        await MainActor.run { self.user?.connectedTo += [userName] }
+        try await localStorageService.addConnection(of: user, with: [otherUserName])
+        await MainActor.run { self.user?.connectedTo += [otherUserName] }
     }
 }
 

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -116,6 +116,64 @@ final class UserViewModel {
         }
     }
     
+    func signInWithApple() async {
+        do {
+             // 1. 현재 Firebase Auth 사용자가 존재하는지 확인
+             guard let currentUser = Auth.auth().currentUser else {
+                 // 아직 Apple Credential로 인증되지 않았거나
+                 // Apple 로그인 프로세스가 완료되지 않은 상황
+                 print("애플 로그인: 현재 사용자가 존재하지 않음 (Auth)")
+                 return
+             }
+             
+             // 2. 이메일 가져오기
+             let email = currentUser.email ?? "No email"
+             print("애플 로그인 이메일: \(email)")
+
+             // 3. Firestore에서 사용자 정보 확인
+             guard let user = try await remoteStorageService.fetchUserByEmail(email) else {
+                 // Firestore에 사용자 정보가 없다면 -> 회원가입(이름/역할 설정)이 안 된 상태
+                 // 애플 로그인만 완료된 상태이므로, 로컬 정보 저장 없이 로그아웃 or 추가 흐름
+                 print("애플 로그인: Firestore에 사용자 정보 없음. 회원가입 필요")
+                 
+                 // 원한다면 로그아웃
+                 try Auth.auth().signOut()
+                 return
+             }
+            
+             try await localStorageService.addUser(user)
+             
+             // 4. VM State 업데이트
+             await MainActor.run {
+                 self.user = user
+                 self.state = user.isConnected ? .connected(user.role) : .notConnected
+             }
+             
+             print("애플 로그인: Firestore 사용자 정보 확인 완료. State 업데이트.")
+
+         } catch let error as NSError {
+             // Apple 로그인 / Firebase Auth 에러 처리
+             print("애플 로그인 실패: \(error.localizedDescription)")
+             
+             // 추가적인 에러 분기 (AuthErrorCode) 필요하다면
+             if let authError = AuthErrorCode.Code(rawValue: error.code) {
+                 switch authError {
+                 case .invalidEmail:
+                     await GlobalAlert.shared.show(message: "이메일 형식이 올바르지 않습니다.")
+                 case .wrongPassword:
+                     await GlobalAlert.shared.show(message: "비밀번호가 맞지 않습니다.")
+                 case .userDisabled:
+                     await GlobalAlert.shared.show(message: "사용할 수 없는 계정입니다.")
+                 default:
+                     await GlobalAlert.shared.show(message: "애플 로그인 에러: \(error.localizedDescription)")
+                 }
+             } else {
+                 // Firestore 관련 에러 등
+                 await GlobalAlert.shared.show(message: "애플 로그인 에러: \(error.localizedDescription)")
+             }
+         }
+    }
+    
     func checkNameAvailable(name: String) async -> Bool {
         do {
             // 1. 기존 유저 존재 여부 확인
@@ -151,14 +209,7 @@ final class UserViewModel {
     }
     
     func signUp(name: String, email: String, password: String, role: Role) async throws {
-        //_ = try await Auth.auth().createUser(withEmail: email, password: password)
-        do {
-            _ = try await Auth.auth().createUser(withEmail: email, password: password)
-            print("Firebase Auth 사용자 생성 성공: \(email)")
-        } catch let error as NSError {
-            print("Firebase Auth 에러 - 코드: \(error.code), 메시지: \(error.localizedDescription)")
-            throw error
-        }
+        _ = try await Auth.auth().createUser(withEmail: email, password: password)
         
         let user = User(name: name, role: role, email: email, connectedTo: [])
         
@@ -168,6 +219,12 @@ final class UserViewModel {
     func signUpWithApple(name: String, email: String, role: Role) async throws {
         // Firebase Auth에는 이미 계정이 있으므로 Firestore에만 저장
         let user = User(name: name, role: role, email: email, connectedTo: [])
+        
+        await MainActor.run {
+            self.user = user
+            self.state = .notConnected
+        }
+        
         try await remoteStorageService.addUser(user)
         
         print("애플 회원가입(추가 정보) 완료 - \(email)")


### PR DESCRIPTION
# 애플 로그인 구현
- 애플로그인 버튼(View) - UserViewModel에 관련 기능 구현 - MainLoginView, SignUpNameView 등으로 분기
의 플로우로 구현하였습니다.

## 애플 로그인 버튼
- 기본 컴포넌트인 SignInWithAppleButton()을 사용하였으며
- onCompletion 단계에서 새 사용자인지, 기존 사용자인지 구분하여 뷰 이동을 시켰습니다. 
- 애플 로그인시 비밀번호는 필요없기 때문에 비밀번호가 필요한 뷰인 ```SignUpNameView```로 넘겨주기 위해 ```password```애 빈 문자열 ```""```을 넘겨주었습니다.
``` swift
SignInWithAppleButton(
            .continue,
            onRequest: { request in
                userVM.configureAppleSignInRequest(request)
            },
            onCompletion: { result in
                Task {
                    if let (isNewUser, email) = await userVM.processAppleSignInResult(result) {
                        if isNewUser {
                            // 새 사용자 => 회원가입 플로우
                            print("Apple 회원가입, 이름입력하러 가자")
                            navigationManager.push(to: .signUpName(
                                email: email,
                                password: "" // 애플 회원가입용
                            ))
                        } else {
                            // 기존 사용자 => 홈 화면
                            await userVM.signInWithApple()
                            navigationManager.popToRoot()
                        }
                    } else {
                        print("Apple 로그인 실패 또는 취소됨")
                    }
                }
            }
        )
```

## UserViewModel에 애플로그인 관련 로직 추가
애플로그인 버튼을 누르면 - Firebase Auth에 애플 로그인 정보를 등록

- onRequest에서 Firebase에 요청할 정보(이매알, 이름)과 랜덤난수를 초기화 해줍니다.
### configureAppleSignInRequest
``` swift
        self.nounce = randomNonceString()
        request.requestedScopes = [.email, .fullName]
        request.nonce = sha256(nounce)
```
### processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> (Bool, String)?
- 유저정보와 이메일을 받아옵니다. (```performAppleFirebaseSignIn(credential: credential)```애서 성공시)
``` swift
case .success(let authorization):
                if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
                    do {
                        let (isNewUser, email) = try await performAppleFirebaseSignIn(credential: credential)
                        return (isNewUser, email)
                    } catch {
                        print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
                        return nil
                    }
```
- ```performAppleFirebaseSignIn(credential: credential)```애서는 nounce와 토큰을 통해 이메일과 이름 정보를 가져옵니다.(credential)

## 애플로그인용 signIn, signUp

- 이메일용 signUp과 다르게 auth.().createUser를 하지 않고 (이미 생성됨)
- 유저 정보와 상태를 원격, 로컬에 등록해줍니다. 
### signUpWithApple(name: String, email: String, role: Role)
``` swift
        let user = User(name: name, role: role, email: email, connectedTo: [])
        
        try await remoteStorageService.addUser(user)
        try await localStorageService.addUser(user)
        
        await MainActor.run {
            self.user = user
            self.state = .notConnected
        }
```

- 이미 애플로그인 버튼을 눌러 로그인이 된 상황이므로 이메일용 signIn과 다르게 auth login을 하지 않습니다.
- Firebase Auth에 사용자가 있는 지 확인, 있다면 정보를 가져와 로컬에 사용자를 반영
### signInWithApple()
``` swift
             // 1. 현재 Firebase Auth 사용자가 존재하는지 확인
             guard let currentUser = Auth.auth().currentUser else {
                 // 아직 Apple Credential로 인증되지 않았거나
                 // Apple 로그인 프로세스가 완료되지 않은 상황
                 print("애플 로그인: 현재 사용자가 존재하지 않음 (Auth)")
                 return
             }
             
             // 2. 이메일 가져오기
             let email = currentUser.email ?? "No email"
             print("애플 로그인 이메일: \(email)")

             // 3. Firestore에서 사용자 정보 확인
             guard let user = try await remoteStorageService.fetchUserByEmail(email) else {
                 // Firestore에 사용자 정보가 없다면 -> 회원가입(이름/역할 설정)이 안 된 상태
                 // 애플 로그인만 완료된 상태이므로, 로컬 정보 저장 없이 로그아웃 or 추가 흐름
                 print("애플 로그인: Firestore에 사용자 정보 없음. 회원가입 필요")
                 
                 // 원한다면 로그아웃
                 try Auth.auth().signOut()
                 return
             }
             try await localStorageService.addUser(user)
             
             // 4. VM State 업데이트
             await MainActor.run {
                 self.user = user
                 self.state = user.isConnected ? .connected(user.role) : .notConnected
             }
```

## SignUpRoleView에서 분기(애플, 이메일)
- 보안부분에서 가장 민감하게 생각하던 부분이었으나
- 이메일에서는 이미 가입시 비밀번호를 6자리 이상 작성하여야 하며, 애플로그인은 비밀번호가 필요없다는 점을 이용해 password를 기준으로 분기하였습니다. 
``` swift
                        if password == "" {
                            print("Apple Login 중 회원가입 누름")
                            // 애플 회원가입
                            try await userVM.signUpWithApple(name: name, email: email, role: selectedRole)

                            // 애플 회원가입 완료 후 홈 화면으로 이동
                            await MainActor.run {
                                navigationManager.popToRoot()
                            }
                        } else {
                            // 이메일 회원가입
                            try await userVM.signUp(name: name, email: email, password: password, role: selectedRole)

                            // 이메일 회원가입 완료 후 로그인 화면으로 이동
                            await MainActor.run {
                                navigationManager.pop(to: .emailLogin)
                            }
                        }
```
- 해당 뷰로 넘어온 password가 "" 라면 애플로그인이고, 이메일 가입자로서는 들어올 수 없는 플로우 이므로 적용
- 해당 뷰는 회원가입시 역할선택 뷰로 선택된 역할을 원격과 로컬에 등록
- await를 이용하여 회원가입이 완료 된 후 popToRoot를 이용해 홈 화면으로 이동


## 기타 사항
- 기본 플로우 및 코드 배치 피드백 환영합니다...
- 사용자끼리 연결이 되어도 앱 종료 후 재 실행시 ConnectUserView로 넘어옵니다.
- 사용자의 상태가 ```notConnected```라는 소리인데, 로컬과 원격에 상태를 잘 저장했다고 생각했는데 어디가 문제인지 잘 모르겠습니다.
- ```SwiftDataRepository```에서  ```isMemoryOnly```를``` false``` 그대로 납두면 ```ConnectUserView```로 이동하고, ```true```로 바꾸면 앱 재시작시 아예 로컬 정보가 초기화되므로 로그인 자체를 다시해야합니다.