### PR TITLE
Feat: #188 (ReleaseBranch) 사용자 이름 선반영

### DIFF
--- a/PicCharge/PicCharge/Helper/NavigationManager.swift
+++ b/PicCharge/PicCharge/Helper/NavigationManager.swift
@@ -12,7 +12,7 @@ enum PathType: Hashable {
     case mainLogin
     case emailLogin
     case signUpEmailPw
-    case signUpName(email: String, password: String)
+    case signUpName(email: String, password: String, name: String)
     case signUpRole(name: String, email: String, password: String)
     
     // MARK: - 자식
@@ -40,8 +40,8 @@ extension PathType {
             EmailLoginView()
         case .signUpEmailPw:
             SignUpEmailPasswordView()
-        case .signUpName(let email, let password):
-            SignUpNameView(email: email, password: password)
+        case .signUpName(let email, let password, let name):
+            SignUpNameView(email: email, password: password, name: name)
         case .signUpRole(let name, let email, let password):
             SignUpRoleView(name: name, email: email, password: password)
             

--- a/PicCharge/PicCharge/View/Auth/SignUpEmailPasswordView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpEmailPasswordView.swift
@@ -94,7 +94,7 @@ struct SignUpEmailPasswordView: View {
                         isLoading = false
                         
                         if isAvailable {
-                            navigationManager.push(to: .signUpName(email: email, password: password))
+                            navigationManager.push(to: .signUpName(email: email, password: password, name: ""))
                         } else {
                             email = ""
                             password = ""

--- a/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
@@ -12,15 +12,16 @@ struct SignUpNameView: View {
     @Environment(NavigationManager.self) var navigationManager
     @Environment(UserViewModel.self) var userVM
 
-    @State private var name: String = ""
+    @State private var name: String
     @State private var isLoading: Bool = false
     
     private let email: String
     private let password: String
     
-    init(email: String, password: String) {
+    init(email: String, password: String, name: String = "") {
         self.email = email
         self.password = password
+        _name = State(initialValue: name)
     }
     
     var body: some View {
@@ -65,15 +66,6 @@ struct SignUpNameView: View {
         .padding(.bottom, 16)
         .navigationTitle("이름 설정")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            // 현재 로그인한 사용자가 Apple 로그인인지 확인
-            let isAppleUser = Auth.auth().currentUser?.providerData.contains(where: { $0.providerID == "apple.com" }) ?? false
-            
-            if isAppleUser && name.isEmpty {
-                let appleName = userVM.tempAppleFullName.isEmpty ? "사용자" : userVM.tempAppleFullName
-                name = appleName
-            }
-        }
     }
 }
 

--- a/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
+++ b/PicCharge/PicCharge/View/Auth/SignUpNameView.swift
@@ -65,6 +65,15 @@ struct SignUpNameView: View {
         .padding(.bottom, 16)
         .navigationTitle("이름 설정")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            // 현재 로그인한 사용자가 Apple 로그인인지 확인
+            let isAppleUser = Auth.auth().currentUser?.providerData.contains(where: { $0.providerID == "apple.com" }) ?? false
+            
+            if isAppleUser && name.isEmpty {
+                let appleName = userVM.tempAppleFullName.isEmpty ? "사용자" : userVM.tempAppleFullName
+                name = appleName
+            }
+        }
     }
 }
 

--- a/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
+++ b/PicCharge/PicCharge/View/Components/AppleLoginBtn.swift
@@ -20,13 +20,14 @@ struct AppleLoginBtn: View {
             },
             onCompletion: { result in
                 Task {
-                    if let (isNewUser, email) = await userVM.processAppleSignInResult(result) {
+                    if let (isNewUser, email, fullName) = await userVM.processAppleSignInResult(result) {
                         if isNewUser {
                             // 새 사용자 => 회원가입 플로우
                             print("Apple 회원가입, 이름입력하러 가자")
                             navigationManager.push(to: .signUpName(
                                 email: email,
-                                password: "" // 애플 회원가입용
+                                password: "",
+                                name: fullName
                             ))
                         } else {
                             // 기존 사용자 => 홈 화면

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -31,8 +31,6 @@ final class UserViewModel {
     @ObservationIgnored
     private let remoteStorageService: RemoteStorageService
     
-    @ObservationIgnored var tempAppleFullName: String = ""
-    
     init(
         localStorageService: LocalStorageService,
         remoteStorageService: RemoteStorageService
@@ -316,17 +314,14 @@ extension UserViewModel {
         return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
     
-    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> (Bool, String)? {
+    func processAppleSignInResult(_ result: Result<ASAuthorization, Error>) async -> (Bool, String, String)? {
             switch result {
             case .success(let authorization):
                 if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
                     do {
                         let (isNewUser, email, fullName) = try await performAppleFirebaseSignIn(credential: credential)
-                        await MainActor.run {
-                            self.tempAppleFullName = fullName.isEmpty ? "사용자" : fullName
-                            print("[DEBUG] Apple Sign-In tempAppleFullName 저장: \(self.tempAppleFullName)")
-                        }
-                        return (isNewUser, email)
+                        print("[DEBUG] Apple Sign-In: \(isNewUser ? "신규 유저" : "기존 유저"), 이메일: \(email), 이름: \(fullName)")
+                        return (isNewUser, email, fullName)
                     } catch {
                         print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
                         return nil

--- a/PicCharge/UserViewModel.swift
+++ b/PicCharge/UserViewModel.swift
@@ -31,6 +31,8 @@ final class UserViewModel {
     @ObservationIgnored
     private let remoteStorageService: RemoteStorageService
     
+    @ObservationIgnored var tempAppleFullName: String = ""
+    
     init(
         localStorageService: LocalStorageService,
         remoteStorageService: RemoteStorageService
@@ -319,7 +321,11 @@ extension UserViewModel {
             case .success(let authorization):
                 if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
                     do {
-                        let (isNewUser, email) = try await performAppleFirebaseSignIn(credential: credential)
+                        let (isNewUser, email, fullName) = try await performAppleFirebaseSignIn(credential: credential)
+                        await MainActor.run {
+                            self.tempAppleFullName = fullName.isEmpty ? "사용자" : fullName
+                            print("[DEBUG] Apple Sign-In tempAppleFullName 저장: \(self.tempAppleFullName)")
+                        }
                         return (isNewUser, email)
                     } catch {
                         print("Apple Sign-In 처리 실패: \(error.localizedDescription)")
@@ -335,7 +341,7 @@ extension UserViewModel {
             }
         }
     
-    private func performAppleFirebaseSignIn(credential: ASAuthorizationAppleIDCredential) async throws -> (Bool, String) {
+    private func performAppleFirebaseSignIn(credential: ASAuthorizationAppleIDCredential) async throws -> (Bool, String, String) {
         guard let identityToken = credential.identityToken,
               let tokenString = String(data: identityToken, encoding: .utf8) else {
             throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid token"])
@@ -353,13 +359,16 @@ extension UserViewModel {
             throw NSError(domain: "AuthError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing email"])
         }
         
-        // Firestore 조회
-        if let _ = try await remoteStorageService.fetchUserByEmail(email) {
-            // 기존 유저
-            return (false, email)
+        let fullName = credential.fullName?.formatted() ?? ""
+        
+        // 5. Firestore 조회하여 기존 유저 여부 판단
+        if let existingUser = try await remoteStorageService.fetchUserByEmail(email) {
+            // 기존 유저 → Firestore에서 저장된 이름 가져오기
+            let storedName = existingUser.name
+            return (false, email, storedName)
         } else {
-            // 새 유저
-            return (true, email)
+            // 신규 유저 → fullName 저장 필요
+            return (true, email, fullName)
         }
     }
 }


### PR DESCRIPTION
## 애플 로그인 시 사용자 이름을 SignUpNameView 에 미리 채워놓습니다.

### SignUpNameView
- ```.onAppear```에서 애플 로그인 유저인지 확인 후 이름을 불러옵니다.
``` swift
        .onAppear {
            // 현재 로그인한 사용자가 Apple 로그인인지 확인
            let isAppleUser = Auth.auth().currentUser?.providerData.contains(where: { $0.providerID == "apple.com" }) ?? false

            if isAppleUser && name.isEmpty {
                let appleName = userVM.tempAppleFullName.isEmpty ? "사용자" : userVM.tempAppleFullName
                name = appleName
            }
        }
```

### performAppleFirebaseSignIn 에서 이름 받아오기
기존 
``` swift
let (isNewUser, email) = try await performAppleFirebaseSignIn(credential: credential)
```

변경 후
- ```fullName``` 까지 받아오며, ```tempAppleFullName```에 저장합니다.
``` swift
    @ObservationIgnored var tempAppleFullName: String = ""
    ...

    let (isNewUser, email, fullName) = try await performAppleFirebaseSignIn(credential: credential)
    await MainActor.run {
        self.tempAppleFullName = fullName.isEmpty ? "사용자" : fullName
        print("[DEBUG] Apple Sign-In tempAppleFullName 저장: \(self.tempAppleFullName)")
    }
```
---
추가 이야기 
- 애플로그인 시 사용자 정보는 최초 로그인시에만 받아올 수 있습니다. 
- 따라서 ```SignUpNameView```에서 이탈(로컬, 원격 저장 안된상태)하면 재실행시 사용자 이름이 아닌 '사용자' 라고 나타내도록 하였습니다.
- 이탈 시에도 최초 로그인 시 받은 사용자 정보를 SignUpNameView에 띄우려면 
- User 모델의 role을 옵셔널로 바꿔서 ```SignUpNameView```에서 로컬 저장 후 불러오는 방식 또는 role 값을 임의로 .child로 초기화 하는 방법이 있을듯 합니다. 
