### PR TITLE
Fix/image bug

### DIFF
--- a/PicCharge/PicCharge/View/Components/AsyncSquareImage.swift
+++ b/PicCharge/PicCharge/View/Components/AsyncSquareImage.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AsyncSquareImage: View {
     @Environment(PhotoViewModel.self) var photoVM
-    @State private var uiImage: UIImage?
+    @State private var cache: (id: UUID, image: UIImage)?
     
     private let photo: Photo
     private let size: CGSize
@@ -21,12 +21,14 @@ struct AsyncSquareImage: View {
     }
     
     var body: some View {
-        if let uiImage {
-            Image(uiImage: uiImage)
+        if let cache, (cache.id == photo.id) {
+           
+            Image(uiImage: cache.image)
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
             
         } else {
+            
             Color.bgGray
                 .aspectRatio(1, contentMode: .fit)
                 .overlay { ProgressView() }
@@ -43,12 +45,12 @@ struct AsyncSquareImage: View {
     private func loadCache(imgData: Data) async {
         Task.detached {
             if let cachedImage = await ImageCache.shared.image(for: photoId) {
-                await MainActor.run { self.uiImage = cachedImage }
+                await MainActor.run { self.cache = (id: photo.id, image: cachedImage) }
                 return
             }
 
             if let downsampledImage = imgData.downsampling(to: size) {
-                await MainActor.run { self.uiImage = downsampledImage }
+                await MainActor.run { self.cache = (id: photo.id, image: downsampledImage) }
                 await ImageCache.shared.insertImage(downsampledImage, for: photoId)
             }
         }
@@ -60,7 +62,7 @@ struct AsyncSquareImage: View {
         do {
             let data = try await photoVM.downloadPhoto(of: urlString)
             
-            await MainActor.run { self.uiImage = UIImage(data: data) }
+            await MainActor.run { self.cache = (id: photo.id, image: UIImage(data: data)!) }
             
             self.photo.imgData = data
             try await photoVM.updateLocal(of: photo)

--- a/PicCharge/PicCharge/View/Scene/Auth/ConnectUserView.swift
+++ b/PicCharge/PicCharge/View/Scene/Auth/ConnectUserView.swift
@@ -243,7 +243,7 @@ extension ConnectUserView {
             print("업데이트한 request: \(updatedRequest)")
             
             // 연결한 유저 정보 받아오기
-            guard var otherUser = await FirestoreService.shared.fetchUserByName(name: request.from) else {
+            guard let otherUser = await FirestoreService.shared.fetchUserByName(name: request.from) else {
                 alertMessage = "연결 요청한 유저를 찾을 수 없습니다."
                 isShowingAlert = true
                 return

--- a/PicCharge/PicCharge/View/Scene/Parent/ParentAlbumView.swift
+++ b/PicCharge/PicCharge/View/Scene/Parent/ParentAlbumView.swift
@@ -87,7 +87,7 @@ struct ParentAlbumView: View {
         }
         .refreshable {
             Task {
-                try await photoVM.syncPhoto(of: userVM.user?.name)
+                await photoVM.syncPhoto(of: userVM.user?.name)
                 WidgetCenter.shared.reloadAllTimelines()
             }
         }


### PR DESCRIPTION
HotFix 이미지 버그 수정

사진을 추가 / 삭제해도 앨범뷰의 메인 이미지가 업데이트 되지 않는 문제 발생

-> 이미지 추가/삭제 시 AlbumView의 body가 호출되면서 AsyncSquareImage의 body를 호출
-> @State로 이전 이미지의 캐시가 SSOT로 남아있음
-> 이전 이미지 캐시가 있으므로 이전 이미지를 그대로 노출되는 현상

-> 새로 변경된 사진의 Id와 @State에 저장된 캐시의 id를 비교하는 로직 추가

```swift
// 기존
@State private var image: UIImage?

if let image { ... 이미지 로직 }

// 변경 후
@State private var cache: (id: UUID, image: UIImage)?

if let cache, (cache.id == photo.id) { ... 이미지 로직 }
```